### PR TITLE
ajout lieu (La Myne)

### DIFF
--- a/locations/lyon.json
+++ b/locations/lyon.json
@@ -25,5 +25,14 @@
         "type": "coffee",
         "power": {"available": true},
         "wifi": {"available": true}
-    }
+    },
+      {
+        "name": "La Myne",
+        "lat": 45,7836213, 
+        "lon": 4,8844091,
+        "address":  "1, rue du Luizet, 69100, Villeurbanne",
+        "type": "Hackerspace",
+        "power": {"available": true},
+        "wifi": {"available": true}
+}
 ]


### PR DESCRIPTION
C'est à Villeurbanne mais bon, ça me semble plus pertinent de le mettre sur l'entrée "Lyon" que de créer une nouvelle localisation.
(Et puis aussi ça me fait un petit exercice pratique de faire l'ajout :p )