### PR TITLE
Add Lieux Communs to Nantes

### DIFF
--- a/locations/bordeaux.json
+++ b/locations/bordeaux.json
@@ -1,5 +1,26 @@
 [
     {
+        "name": "Le Tiers-Lieu de Bègles",
+        "lat": 44.8075735,
+        "lon": -0.5489797,
+        "address":  "1 Place du 14 Juillet, 33130 Bègles",
+        "url": "https://fr-fr.facebook.com/TiersLieuBegles/",
+        "openHours": "Monday to Friday",
+        "type" : "coworking, coop",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    },
+    {
+        "name": "Le Poulailler",
+        "lat": 44.8072838,
+        "lon": -0.5509297,
+        "address":  "1-ter Place du 14 Juillet, 33130 Bègles",
+        "openHours": "Monday to Friday - 08:30am to 09:00pm, Saturday - 09:00am to 01:30pm",
+        "type" : "café,organic groceries,meetups",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    },
+    {
         "name": "Saint Seurin",
         "lat": 44.8437174,
         "lon": -0.5868276,

--- a/locations/brive.json
+++ b/locations/brive.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "Le Chantilly",
+        "lat": 45.158552, 
+        "lon": 1.532314,
+        "address":  "9 Rue du Lion d'or",
+        "url": "https://www.le-chantilly.com/",
+        "openHours": "Monday: 12am to 7pm, Tuesday to Friday: - 11am to 7pm, Saturday: 9:30am to 7pm",
+        "type" : "Tea room",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    }
+]

--- a/locations/crest.json
+++ b/locations/crest.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "Façon chocolat",
+    "lat": 44.7290414,
+    "lon": 5.0255095,
+    "address":  "Place des Moulins, 26400 Crest",
+    "url": "https://www.faconchocolat.fr",
+    "openHours": "Monday to Sunday - 08:00am to 19:30pm",
+    "type" : "café, salon de thé, chocolaterie",
+    "power": {"available": true},
+    "wifi": {"available": false}
+  }
+]

--- a/locations/epinal.json
+++ b/locations/epinal.json
@@ -1,0 +1,13 @@
+[
+    {
+      "name": "Nulle Part Ailleurs",
+      "Opnening": "From monday to saturday, 09h30 - 20h00",
+      "lat": 48.1742592,
+      "lon": 6.4505618,
+      "address": "3 Place Saint-Goery, 88000, Épinal",
+      "type" : "coffee/restaurant",
+      "power": {"available": true},
+      "wifi": {"available": true, "comment": "just ask to the staff :)"},
+      "url": "https://www.facebook.com/nullepartailleursepinal/"
+    }
+]

--- a/locations/gent.json
+++ b/locations/gent.json
@@ -10,5 +10,17 @@
       "wifi": {"available": true, "comment": "just ask to the staff :)"},
       "url": "http://www.husetgent.be/",
       "comment": "Nice coffee that makes affordable lunches in an ancient hostel. Really sweet terrace in the back."
+    },
+     {
+      "name": "Vooruit",
+      "Opnening": "Mon, Tue, Wed-> 10:00 - 01:00 / Thu, Fri, Sat -> 10:00 - 02:00 / Sun -> 12:00 - 01:00",
+      "lat": 51.0476851,
+      "lon": 3.7274632,
+      "address": "Sint-Pietersnieuwstraat 23, Gand 9000",
+      "type" : "coffee/restaurant/bar/art center",
+      "power": {"available": true, "comment": "some multi-sockets next to the tables nearby the walls"},
+      "wifi": {"available": true, "comment": "kind of intranet, no password required"},
+      "url": "http://vooruit.be/en/",
+      "comment": "Huge friendly place with local beers. An institution."
     }
 ]

--- a/locations/gent.json
+++ b/locations/gent.json
@@ -1,0 +1,14 @@
+[
+    {
+      "name": "Huset",
+      "Opnening": "From monday to friday, 11h00 - 18h00",
+      "lat": 51.0548247,
+      "lon": 3.7131703000000016,
+      "address": "Hoogstraat 49, 9000 Gent",
+      "type" : "coffee/restaurant",
+      "power": {"available": true, "comment": "many multi-sockets next to the tables"},
+      "wifi": {"available": true, "comment": "just ask to the staff :)"},
+      "url": "http://www.husetgent.be/",
+      "comment": "Nice coffee that makes affordable lunches in an ancient hostel. Really sweet terrace in the back."
+    }
+]

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -204,6 +204,12 @@
         "defaultZoom":  13
     },
     {
+        "name" : "Sète",
+        "lat" : 43.3942538,
+        "lon" : 3.6122974,
+        "defaultZoom":  13
+    },
+    {
         "name" : "Liège",
         "lat" : 50.6246191,
         "lon" : 5.5290505,

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -174,6 +174,12 @@
         "defaultZoom": 12
     },
     {
+        "name" : "Nîmes",
+        "lat" : 43.8375711,
+        "lon" : 4.3413666,
+        "defaultZoom": 14
+    },
+    {
         "name" : "Nantes",
         "lat" : 47.2081436,
         "lon" : -1.5619954,

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -203,10 +203,16 @@
         "lon" : 5.5290505,
         "defaultZoom":  12
     },
-	{
+    {
         "name" : "Brive-la-Gaillarde",
         "lat" : 45.158878,
         "lon" : 1.533141,
         "defaultZoom":  15
+    },
+    {
+        "name" : "Rouen",
+        "lat" : 49.4404,
+        "lon" : 1.0926, 
+        "defaultZoom": 15
     }
 ]

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -48,6 +48,12 @@
         "defaultZoom": 14
     },
     {
+        "name": "Crest",
+        "lat": 44.7311897,
+        "lon": 4.98612,
+        "defaultZoom": 13
+    },
+    {
         "name": "Cumbria",
         "lat": 54.6190,
         "lon": -2.9004,

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -60,9 +60,21 @@
         "defaultZoom":  13
     },
     {
+        "name": "Epinal",
+        "lat": 48.174517,
+        "lon": 6.450162,
+        "defaultZoom":  13
+    },
+    {
         "name": "Fronton",
         "lat": 43.840098,
         "lon": 1.389654,
+        "defaultZoom":  13
+    },
+    {
+        "name": "Gent",
+        "lat": 51.052974,
+        "lon": 3.7270591,
         "defaultZoom":  13
     },
     {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -72,6 +72,12 @@
         "defaultZoom":  14
     },
     {
+        "name": "Luxembourg",
+        "lat": 49.6,
+        "lon": 6.116667,
+        "defaultZoom":  14
+    },
+    {
         "name": "Herault",
         "lat": 43.7453,
         "lon": 3.6172,

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -202,5 +202,11 @@
         "lat" : 50.6246191,
         "lon" : 5.5290505,
         "defaultZoom":  12
+    },
+	{
+        "name" : "Brive-la-Gaillarde",
+        "lat" : 45.158878,
+        "lon" : 1.533141,
+        "defaultZoom":  15
     }
 ]

--- a/locations/london.json
+++ b/locations/london.json
@@ -1,4 +1,34 @@
 [
+   {
+        "name": "Brunswick East",
+        "lat": 51.5491713,
+        "lon": -0.0789717,
+        "address": "Stamford Works, Gillett St, London N16 8JH",
+        "openHours": "Monday to Friday, 08:00 to 17:00; Saturday and Sunday, 09:00 to 17:00",
+        "type": "coffee shop, homemade, open kitchen",
+        "power": { "available": true },
+        "wifi": { "available": true }
+    },
+   {
+        "name": "South Library",
+        "lat": 51.5390506,
+        "lon": -0.1008359,
+        "address": "117 Essex Rd, London N1 2SL",
+        "openHours": "Monday and Wednesday, 09:30 to 20:00; Friday and Saturday, 09:30 to 17:00",
+        "type": "library, quiet",
+        "power": { "available": true },
+        "wifi": { "available": true }
+    },
+    {
+        "name": "Mildmay Library",
+        "lat": 51.5476059,
+        "lon": -0.0865848,
+        "address": "21-23 Mildmay Park, London N1 4NA",
+        "openHours": "Monday, 09:30 to 13:00; Tuesday and Thursday, 09:30 to 20:00; Saturday, 11:00 to 17:00",
+        "type": "library, quiet",
+        "power": { "available": true },
+        "wifi": { "available": true }
+    },
     {
         "name": "Kobo",
         "lat": 51.5350033,

--- a/locations/london.json
+++ b/locations/london.json
@@ -1,11 +1,21 @@
 [
     {
+        "name": "Kobo",
+        "lat": 51.5350033,
+        "lon": -0.1063137,
+        "address": "346 Upper St, London N1 0PD",
+        "openHours": "Monday to Friday, 07:00 to 19:00; Saturday and Sunday, 09:30 to 17:30",
+        "type": "coffee, bakery",
+        "power": { "available": true },
+        "wifi": { "available": true }
+    },
+    {
         "name": "Dandy",
         "lat": 51.551252,
         "lon": -0.0864523,
         "address": "20 Newington Green, London N16 9PU",
         "openHours": "Monday to Wednesday, 08:00 to 17:00; Thursday to Sunday, 08:00 to 23:00",
-        "type": "coffee, bakery, restaurant",
+        "type": "coffee, bakery, restaurant, quiet",
         "power": { "available": true },
         "wifi": { "available": true }
     },

--- a/locations/london.json
+++ b/locations/london.json
@@ -5,7 +5,7 @@
         "lon": -0.1063137,
         "address": "346 Upper St, London N1 0PD",
         "openHours": "Monday to Friday, 07:00 to 19:00; Saturday and Sunday, 09:30 to 17:30",
-        "type": "coffee, bakery",
+        "type": "coffee, bakery, quiet",
         "power": { "available": true },
         "wifi": { "available": true }
     },
@@ -15,7 +15,7 @@
         "lon": -0.0864523,
         "address": "20 Newington Green, London N16 9PU",
         "openHours": "Monday to Wednesday, 08:00 to 17:00; Thursday to Sunday, 08:00 to 23:00",
-        "type": "coffee, bakery, restaurant, quiet",
+        "type": "coffee, bakery, restaurant",
         "power": { "available": true },
         "wifi": { "available": true }
     },

--- a/locations/luxembourg.json
+++ b/locations/luxembourg.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "Kathy's Deli & Cupcakery",
+        "openHours": "Monday - Friday: 08h00 - 18h00, Saturday: 08h00 - 16h00",
+        "lat": 49.6011223,
+        "lon": 6.1319008,
+        "address":  "9 Rue de Strasbourg, 2561 Luxembourg",
+        "type" : "Restaurant, Cupcakes & Coffee Shop",
+        "wifi": {"available": true},
+        "power": {"available": true},
+        "url": "https://www.facebook.com/KathysCupcakery/"
+    }
+]

--- a/locations/lyon.json
+++ b/locations/lyon.json
@@ -25,5 +25,14 @@
         "type": "coffee",
         "power": {"available": true},
         "wifi": {"available": true}
-    }
+    },
+    {
+        "name": "Le Labo",
+        "lat": 45.75029,
+        "lon": 4.83938,
+        "address":  "39 rue de Marseille, 69002, Lyon",
+        "type": "coffee",
+        "power": {"available": true},
+        "wifi": {"available": true}
+}
 ]

--- a/locations/lyon.json
+++ b/locations/lyon.json
@@ -16,5 +16,14 @@
         "type": "coffee",
         "power": {"available": true},
         "wifi": {"available": true}
+    },
+    {
+        "name": "Puzzle Café",
+        "lat": 45.764192,
+        "lon": 4.833711,
+        "address":  "4 rue de la poullaillerie, 69002, Lyon",
+        "type": "coffee",
+        "power": {"available": true},
+        "wifi": {"available": true}
     }
 ]

--- a/locations/marseille.json
+++ b/locations/marseille.json
@@ -1,4 +1,16 @@
 [
+     {
+        "name": "L'apparte",
+        "lat": 43.2912719,
+        "lon": 5.3847606,
+        "openHours": "Monday to Saturday, 10h00 - 19h00",
+        "address":  "6 Rue de Lodi, 13006 Marseille",
+        "type" : "coffeeshop/tearoom",
+        "url": "http://lapparte.business.site/",
+        "comment": "y'a un petit patio au calme et une grande table à l'intérieur pour bosser tranquille",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    },
     {
         "name": "Café x Café",
         "lat": 43.2926049,

--- a/locations/marseille.json
+++ b/locations/marseille.json
@@ -1,5 +1,26 @@
 [
     {
+        "name": "Café x Café",
+        "lat": 43.2926049,
+        "lon": 5.3847225,
+        "openHours": "Monday to Friday, 08h00 - 16h00; Saturday to Sunday, 09h00 - 13h00",
+        "address":  "2B Rue Fontange, 13006 Marseille",
+        "type" : "coffeeshop",
+        "power": {"available": false},
+        "wifi": {"available": false}
+    },
+    {
+        "name": "Histoire de l'œil",
+        "lat": 43.2921037,
+        "lon": 5.3830756,
+        "openHours": "Tuesday to Saturday, 10h00 - 19h00",
+        "address":  "25 Rue Fontange, 13006 Marseille 06",
+        "type" : "bookshop",
+        "url": "http://histoiredeloeil.com",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    },
+    {
         "name": "Le Môle",
         "lat": 43.29531,
         "lon": 5.36180,

--- a/locations/marseille.json
+++ b/locations/marseille.json
@@ -7,7 +7,7 @@
         "address":  "2B Rue Fontange, 13006 Marseille",
         "type" : "coffeeshop",
         "power": {"available": false},
-        "wifi": {"available": false}
+        "wifi": {"available": false, "comment": "à vérifier, je n'ai pas demandé"}
     },
     {
         "name": "Histoire de l'œil",
@@ -15,6 +15,7 @@
         "lon": 5.3830756,
         "openHours": "Tuesday to Saturday, 10h00 - 19h00",
         "address":  "25 Rue Fontange, 13006 Marseille 06",
+        "comment": "y'a des tables en intérieur _et_ en extérieur, à l'ombre d'un arbre",
         "type" : "bookshop",
         "url": "http://histoiredeloeil.com",
         "power": {"available": true},

--- a/locations/montpellier.json
+++ b/locations/montpellier.json
@@ -281,23 +281,12 @@
     },
     {
         "name": "Chez Théo",
-        "lat": 43.6123468,
-        "lon": 3.8788032,
+        "lat": 43.6122344,
+        "lon": 3.8769202,
         "openHours": "From Monday to Saturday - 11:00am to 7:00pm",
         "address": "45 rue de l'Aiguillerie - 34000 Montpellier",
         "type": "Coffee",
         "url": "http://chez-theo.org/",
-        "power": {"available": true },
-        "wifi": {"available": true }
-    },
-    {
-        "name": "Le Dada Café",
-        "lat": 43.6123468,
-        "lon": 3.8788032,
-        "openHours": "From Monday to Friday - 8:00am to 4:00pm",
-        "address": "43 rue de l'Université - 34000 Montpellier",
-        "type": "Restaurant, pub, coffee",
-        "url": "https://www.facebook.com/le-dada-caf%C3%A9-280554891960129/",
         "power": {"available": true },
         "wifi": {"available": true }
     }

--- a/locations/montpellier.json
+++ b/locations/montpellier.json
@@ -64,17 +64,6 @@
         "wifi": {"available": false}
     },
     {
-        "name": "Fairview Coffee",
-        "lat": 43.606992,
-        "lon": 3.877552,
-        "openHours": "Tuesday to Saturday - 9:30am to 7:00pm and Sundays - 11:00am to 5:00pm",
-        "address":  "6, rue Loys",
-        "type": "Coffee and Restaurant",
-        "url": "https://www.facebook.com/FairviewCoffee",
-        "power": {"available": true },
-        "wifi": {"available": true }
-    },
-    {
         "name": "La Panacée",
         "lat": 43.61282,
         "lon": 3.87811,

--- a/locations/montpellier.json
+++ b/locations/montpellier.json
@@ -61,7 +61,7 @@
         "type" : "Coffee and Restaurant",
         "url": "https://fr-fr.facebook.com/BUNcafe",
         "power": {"available": true},
-        "wifi": {"available": true}
+        "wifi": {"available": false}
     },
     {
         "name": "Fairview Coffee",

--- a/locations/nimes.json
+++ b/locations/nimes.json
@@ -1,0 +1,23 @@
+	[
+	    {
+	        "name": "Le Prolé",
+	        "lat": 43.8343513,
+	        "lon": 4.3573299,
+	        "openHours": "From Monday to Saturday - 08:00am to 10:00pm",
+	        "address": "20 Rue Jean Reboul, 30900 Nîmes",
+	        "type": "Café, patio",
+	        "power": {"available": true },
+	        "wifi": {"available": false }
+	    },
+      {
+	        "name": "Musée de la Romanité",
+	        "lat": 43.8338312,
+	        "lon": 4.3574534,
+	        "openHours": "From Monday to Sunday - 10:00am to 7:00pm",
+	        "address": "16 Boulevard des Arènes, 30900 Nîmes",
+	        "type": "Museum, café, garden",
+	        "url": "https://museedelaromanite.fr/",
+	        "power": {"available": false },
+	        "wifi": {"available": false }
+	    }
+	]

--- a/locations/paris.json
+++ b/locations/paris.json
@@ -1,4 +1,16 @@
 [
+   {
+        "name": "Ménagerie de Verre",
+        "lat": 48.8631985,
+        "lon": 2.3763201,
+        "address": "12 Rue Lechevin, 75011 Paris",
+        "openHours" : "Monday to Sunday: 10h00-18h00",
+        "type": "danse, vegetarian, cafe, office space",
+        "comment" : "Café/restaurant dans un lieu atypique et préservé, calme et lumineux, brassant les pratiques de la danse et de la crétaion graphique.",
+        "url": "http://www.menagerie-de-verre.org/",
+        "power": {"available": false},
+        "wifi": {"available": false}
+    },
     {
         "name": "Café Jeux Natéma",
         "lat": 48.85668,

--- a/locations/paris.json
+++ b/locations/paris.json
@@ -1,4 +1,15 @@
-[    
+[
+    {
+        "name": "Café Jeux Natéma",
+        "lat": 48.85668,
+        "lon": 2.3995703,
+        "address": "39 Rue des Orteaux, 75020 Paris",
+        "openHours" : "Monday to Friday: 9h00-19h00",
+        "type": "coffee, board games",
+        "comment" : "Le café jeux Natema propose des repas, des boissons, des jeux, des loisirs créatifs, des soirées à thème pour tous les âges.",
+        "url": "https://www.facebook.com/cafejeuxnatema/",
+        "power": {"available": true}
+    },
     {
         "name": "Mel, Mich & Martin",
         "lat": 48.8509681,

--- a/locations/paris.json
+++ b/locations/paris.json
@@ -137,5 +137,17 @@
         "url": "http://zouzoucafe.com",
         "power": {"available": true},
         "wifi": {"available": true}
+    },
+    {
+        "name": "Blackburn Café Show",
+        "lat": 48.8736257,
+        "lon": 2.3437387,
+        "address": "34 Rue Richer, 75009 Paris",
+        "openHours" : "10h00-21h00",
+        "type": "coffee, theatre, juice, light food",
+        "comment" : "A bright and quiet tiny place with a joint theatre ticket office.",
+        "url": "http://www.blackburn-paris.com/",
+        "power": {"available": true},
+        "wifi": {"available": true}
     }
 ]

--- a/locations/rouen.json
+++ b/locations/rouen.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "Au Café Couture",
+        "lat": 49.36319,
+        "lon": 1.10273,
+        "openHours": "Wednesday to Saturday - 10am to 12am and 2pm to 8pm",
+        "address": "7, rue Alsace-Lorraine 76000 Rouen",
+        "url": "http://aucafecouturerouen.fr/",
+        "type": "coffee, juice",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    },
+    {
         "name": "Café Dessiné",
         "lat": 49.4406527,
         "lon": 1.0984240,

--- a/locations/rouen.json
+++ b/locations/rouen.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "Café Dessiné",
+        "lat": 49.4406527,
+        "lon": 1.0984240,
+        "openHours": "Tuesday - 10am to 7pm - Wednesday - 9am to 7pm - Thursday to Saturday - 9am to 10pm - Sunday - 11am to 7pm",
+        "address":  "31, rue Damiette 76000 Rouen",
+        "url": "http://cafedessine.fr/",
+        "type": "Brunch, Breakfast, Lunch, Games, Comics, Coffee Shop",
+        "power": {"available": true},
+        "wifi": {"available": true}
+    }
+]

--- a/locations/sete.json
+++ b/locations/sete.json
@@ -1,0 +1,12 @@
+	[
+	  {
+	    "name": "Le bar à lire",
+	    "lat": 43.4010859,
+	    "lon": 3.6942383,
+	    "address":  "Grand'rue Mario Roustan 28, 34200 Sète",
+	    "openHours": "Tuesday to Saturday - 10:00am to 19:00pm",
+	    "type" : "café, jus, plat du jour",
+	    "power": {"available": false},
+	    "wifi": {"available": false}
+	  }
+	]

--- a/locations/toulouse.json
+++ b/locations/toulouse.json
@@ -249,5 +249,27 @@
         "power": {"available": true},
         "wifi": {"available": true},
         "url": "https://fr-fr.facebook.com/sweethomecafe31/"
+    },
+    {
+        "name": "Le Bonheur est dans le Pot",
+        "openHours": "Tuesday and Saturday: 11:00 - 22:30, All other days 11:00 - 19:00",
+        "lat": 43.6035675,
+        "lon": 1.4349094,
+        "address": "17 place saint Pierre",
+        "type" : "coffee/restaurant/shop",
+        "power": {"available": true},
+        "wifi": {"available": true},
+        "url": "https://www.facebook.com/pg/lesamisdubonheur/"
+    },
+    {
+        "name": "Magnolia café",
+        "openHours": "Monday - Saturday: 10:30 - 18:30",
+        "lat": 43.5994,
+        "lon": 1.4439,
+        "address": "49, Rue des Filatiers",
+        "type" : "coffee/restaurant",
+        "power": {"available": true},
+        "wifi": {"available": true},
+        "url": "https://www.facebook.com/Magnolia-Caf%C3%A9-108114426194417/"
     }
 ]

--- a/locations/toulouse.json
+++ b/locations/toulouse.json
@@ -249,5 +249,16 @@
         "power": {"available": true},
         "wifi": {"available": true},
         "url": "https://fr-fr.facebook.com/sweethomecafe31/"
+    },
+    {
+        "name": "L'Eurêkafé",
+        "openHours": "Monday - Friday: 09:00 - 22:00, Saturday & Sunday: 11:00 - 22:00",
+        "lat": 43.6026852,
+        "lon": 1.4392912,
+        "address": "24 Rue Léon Gambetta",
+        "type" : "slow/scientific coffee",
+        "power": {"available": true},
+        "wifi": {"available": true},
+        "url": "https://www.eurekafe.fr/"
     }
 ]

--- a/locations/toulouse.json
+++ b/locations/toulouse.json
@@ -155,7 +155,7 @@
     {
         "name": "Le Parc",
         "openHours": "Monday - Friday, 7h30 - 21h00",
-        "lat": 43.635600,
+        "lat": 43.63597,
         "lon": 1.384067,
         "address":  "3 pl Marronniers, 31700 BLAGNAC, phone:05 61 71 61 71",
         "type" : "coffee/restaurant",
@@ -253,7 +253,7 @@
     {
         "name": "Le Bonheur est dans le Pot",
         "openHours": "Tuesday and Saturday: 11:00 - 22:30, All other days 11:00 - 19:00",
-        "lat": 43.6035675,
+        "lat": 43.60361,
         "lon": 1.4349094,
         "address": "17 place saint Pierre",
         "type" : "coffee/restaurant/shop",
@@ -262,26 +262,27 @@
         "url": "https://www.facebook.com/pg/lesamisdubonheur/"
     },
     {
-        "name": "Magnolia café",
-        "openHours": "Monday - Saturday: 10:30 - 18:30",
-        "lat": 43.5994,
-        "lon": 1.4439,
-        "address": "49, Rue des Filatiers",
-        "type" : "coffee/restaurant",
-        "power": {"available": true},
-        "wifi": {"available": true},
-        "url": "https://www.facebook.com/Magnolia-Caf%C3%A9-108114426194417/"
-    }, 
-    {
         "name": "L'Eurêkafé",
         "openHours": "Monday - Friday: 09:00 - 22:00, Saturday & Sunday: 11:00 - 22:00",
         "lat": 43.6026852,
-        "lon": 1.4392912,
+        "lon": 1.44147,
         "address": "24 Rue Léon Gambetta",
-        "type" : "slow/scientific coffee",
+        "type" : "slow / scientific coffee / board games",
         "power": {"available": true},
         "wifi": {"available": true},
-        "url": "https://www.eurekafe.fr/"
-
+        "url": "https://www.eurekafe.fr/", 
+        "comment": "Scientific coffe. Pay by time spent. Some private room avaiable for free for meetings. Noisy with board-gamers after 16:30."
+    }, 
+    {
+        "name": "Der Apfelstrudel",
+        "openHours": "Tuesday - Friday: 08:00 - 18:00, Saturday & Sunday: 9:30:00 - 18:00",
+        "lat": 43.63637,
+        "lon": 1.38231,
+        "address": "2 cheminement des Sophoras 31700 Blagnac",
+        "type" : "coffee and teamroom",
+        "power": {"available": true},
+        "wifi": {"available": true},
+        "url": "https://www.derapfelstrudel.com/",
+        "comment": "German tea-room, with huge cakes filled with lot of cream. Quiet, free wifi"
     }
 ]

--- a/locations/toulouse.json
+++ b/locations/toulouse.json
@@ -240,7 +240,7 @@
         "url": "http://www.raslatasse.fr"
     },
     {
-        "name": "Home sweet cafe",
+        "name": "Sweet Home Café",
         "openHours": "Tuesday - Friday: 08:30 - 19:00, Saturday: 09:00 - 19:00, Sunday: 10:00 - 19:00",
         "lat": 43.602162,
         "lon": 1.441109,

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@ Dev friendly places
 ===================
 A collection of nice places where developers can work fine and some useful informations about these places (wifi ? power ? ...) on the map of a location.
 
-These nice places can be seen on a map on [https://devfriendlyplaces.net](https://devfriendlyplaces.net).
+These nice places can be seen on a map on [https://www.devfriendlyplaces.net](https://www.devfriendlyplaces.net).
 
 Contribute
 ----------


### PR DESCRIPTION
`{ "places": [
    {
        "name": "Lieux Communs",
        "openHours": "Friday to Saturday: 10h00 - 19h00",
        "lat": 47.201652,
        "lon": -1.571188,
        "address": "8, Rue Saint Domingue 44200 Nantes",
        "type" : "Tiers-Lieu ESS",
        "power": {"available": true, "comment": "directly on most of the tables"},
        "wifi": {"available": true},
        "url": "https://www.lieuxcommuns.coop/"
    },
    
    }
  ]
}`